### PR TITLE
Fetch MD files from API servers too

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -57,12 +57,22 @@ module.exports = {
         text: "API Reference",
         items: externalApisNav.concat([
           {
-            text: "Loom API",
-            link: "/api/loom/v1/"
+            text: "Loom",
+            items: [
+              {
+                text: "API Reference",
+                link: "/api/loom/v1/"
+              }
+            ]
           },
           {
-            text: "OAuth API",
-            link: "/api/oauth/"
+            text: "OAuth",
+            items: [
+              {
+                text: "API Reference",
+                link: "/api/oauth/"
+              }
+            ]
           }
         ])
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3009,6 +3009,16 @@
         "whatwg-fetch": "2.0.3"
       },
       "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
         "whatwg-fetch": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
@@ -6277,6 +6287,18 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isomorphic-form-data": {
@@ -7279,14 +7301,10 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-forge": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "js-yaml-loader": "^1.2.2",
     "jsonwebtoken": "^8.5.1",
     "jwk-to-pem": "^2.0.3",
+    "node-fetch": "^2.6.0",
     "swagger-ui": "^3.25.0",
     "vue-server-renderer": "2.6.10",
     "vuepress": "^1.2.0",

--- a/scripts/fetchDocs.js
+++ b/scripts/fetchDocs.js
@@ -1,9 +1,15 @@
-const https = require("https");
+const fetch = require('node-fetch');
 const fs = require("fs");
 const path = require("path");
 
+async function asyncForEach(array, callback) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
+}
+
 const AVAILABLE_APPS = {
-  directory: "https://directory.heidelberg.cloud"
+  directory: "https://directory.zaikio.com"
 };
 
 const navFilePath = path.join(
@@ -17,60 +23,78 @@ fs.writeFile(navFilePath, JSON.stringify([]), err => {
   }
 });
 
-Object.keys(AVAILABLE_APPS).forEach(appName => {
+Object.keys(AVAILABLE_APPS).forEach(async appName => {
   const url = AVAILABLE_APPS[appName];
-  https.get(`${url}/docs/manifest.json`, response => {
-    response.on("data", data => {
-      const manifest = JSON.parse(data);
-      const appApiDir = path.join(__dirname, `../docs/api/${appName}`);
-      if (!fs.existsSync(appApiDir)) {
-        fs.mkdirSync(appApiDir);
-      }
-      console.log("FETCHED MANIFEST", manifest);
+  const manifest = await fetch(`${url}/docs/manifest.json`).then(res => res.json());
+  const appApiDir = path.join(__dirname, `../docs/api/${appName}`);
+  if (!fs.existsSync(appApiDir)) {
+    fs.mkdirSync(appApiDir);
+  }
+  console.log("FETCHED MANIFEST", manifest);
 
-      if (manifest.specs) {
-        Object.keys(manifest.specs).forEach(specName => {
-          const specPath = manifest.specs[specName];
-          const filePath = path.join(appApiDir, specPath.split("/").pop());
-          const file = fs.createWriteStream(filePath);
-          https.get(`${url}${specPath}`, response => {
-            console.log("FETCHED", `${url}${specPath}`);
-            response.pipe(file);
-            fs.writeFile(
-              path.join(appApiDir, "README.md"),
-              `---
+  if (manifest.specs) {
+    let apiSpecLinks = fs.existsSync(navFilePath)
+      ? JSON.parse(require("fs").readFileSync(navFilePath, "utf8"))
+      : [];
+
+    apiSpecLink = {
+      text: manifest.title,
+      items: []
+    };
+
+    await asyncForEach(Object.keys(manifest.specs), async specName => {
+      const specPath = manifest.specs[specName];
+      const filePath = path.join(appApiDir, specPath.split("/").pop());
+      const response = await fetch(`${url}${specPath}`).then(res => res.text());
+      console.log("FETCHED", `${url}${specPath}`);
+      fs.writeFileSync(filePath, response, err => {
+        if (err) {
+          console.log(err);
+        }
+      });
+      console.log(specPath);
+      apiSpecLinks = fs.existsSync(navFilePath)
+        ? JSON.parse(require("fs").readFileSync(navFilePath, "utf8"))
+        : [];
+
+      if (specPath.includes('.md')) {
+        const path = specPath.split("/").pop().split('.md').shift();
+        apiSpecLink.items.push({
+          text: specName,
+          link: `/api/${appName}/${path}/`
+        });
+      } else {
+        fs.writeFile(
+          path.join(appApiDir, "README.md"),
+          `---
 title: ${specName}
 lang: en-US
 pageClass: full-width
 ---
 
 <ClientOnly><ApiDocWrapper src="api/${appName}/${specPath
-                .split("/")
-                .pop()}"></ApiDocWrapper></ClientOnly>
-            `,
-              err => {
-                if (err) {
-                  console.log(err);
-                }
-              }
-            );
-            let apiSpecLinks = fs.existsSync(navFilePath)
-              ? JSON.parse(require("fs").readFileSync(navFilePath, "utf8"))
-              : [];
-
-            apiSpecLinks.push({
-              text: specName,
-              link: `/api/${appName}/`
-            });
-
-            fs.writeFile(navFilePath, JSON.stringify(apiSpecLinks), err => {
-              if (err) {
-                console.log(err);
-              }
-            });
-          });
+            .split("/")
+            .pop()}"></ApiDocWrapper></ClientOnly>
+        `,
+          err => {
+            if (err) {
+              console.log(err);
+            }
+          }
+        );
+        apiSpecLink.items.push({
+          text: specName,
+          link: `/api/${appName}/`
         });
       }
     });
-  });
+
+    apiSpecLinks.push(apiSpecLink);
+
+    fs.writeFileSync(navFilePath, JSON.stringify(apiSpecLinks), err => {
+      if (err) {
+        console.log(err);
+      }
+    });
+  }
 });


### PR DESCRIPTION
Needed to have the respective event docs as part of directory.

Introduces node-fetch to fetch with promises (not possible with built in libraries :/ ).

- needs https://github.com/crispymtn/zai-directory/pull/267 deployed before